### PR TITLE
[FIX] Migrate project from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/fitting/badge.svg)](https://docs.rs/fitting)
 [![Actions Status](https://github.com/mshrtsr/fitting-rs/workflows/Rust/badge.svg)](https://github.com/mshrtsr/fitting-rs/actions)
 [![CircleCI](https://circleci.com/gh/mshrtsr/fitting-rs.svg?style=shield)](https://circleci.com/gh/mshrtsr/fitting-rs)
-[![Build Status](https://travis-ci.org/mshrtsr/fitting-rs.svg?branch=master)](https://travis-ci.org/mshrtsr/fitting-rs)
+[![Build Status](https://travis-ci.com/mshrtsr/fitting-rs.svg?branch=master)](https://travis-ci.org/mshrtsr/fitting-rs)
 [![codecov](https://codecov.io/gh/mshrtsr/fitting-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/mshrtsr/fitting-rs)
 
 Curve fitting library for Rust


### PR DESCRIPTION
c.f.
Travis-ci .org is moving to Travis-ci .com
https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom