### PR TITLE
ci(.github): update grcov download URL

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ matrix.version == 'nightly' }}
         run: |
           rustup component add llvm-tools-preview
-          curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
 
       - name: Clean
         run: cargo clean


### PR DESCRIPTION
## Why

Because the download URL of the grcov has been changed and test workflow failed.

CI: https://github.com/mshrtsr/fitting-rs/runs/7922961852?check_suite_focus=true
Release: https://github.com/mozilla/grcov/releases/tag/v0.8.11