### PR TITLE
chore: add limitations section of `Gaussian::fit`

### DIFF
--- a/src/gaussian/gaussian.rs
+++ b/src/gaussian/gaussian.rs
@@ -139,6 +139,14 @@ impl<F: Float> Gaussian<F> {
     /// assert_abs_diff_eq!(gaussian, estimated, epsilon = 1e-9);
     /// ```
     ///
+    /// # Limitations
+    ///
+    /// - `x_vec` must have at least one element
+    /// - All elements of `y_vec` must be positive numbers
+    /// - If the distribution is "long-tailed", it affects the fitting accuracy.
+    ///   - A detailed description can be found in Reference 1.
+    ///   - Also, you can see the reproduction and workaround in [GitHub](https://github.com/mshrtsr/fitting-rs/issues/6#issuecomment-1367095969).
+    ///
     /// # References
     /// \[1\] [E. Pastuchov ́a and M. Z ́akopˇcan, ”Comparison of Algorithms for Fitting a Gaussian Function used in Testing Smart Sensors”, Journal of Electrical Engineering, vol. 66, no. 3, pp. 178-181, 2015.](https://www.researchgate.net/publication/281907940_Comparison_of_Algorithms_For_Fitting_a_Gaussian_Function_Used_in_Testing_Smart_Sensors)
     pub fn fit(x_vec: Array1<F>, y_vec: Array1<F>) -> Result<Gaussian<F>, Error> {


### PR DESCRIPTION
## Why

In https://github.com/mshrtsr/fitting-rs/issues/6, we found that the fitting accuracy gets worse with a "long-tailed" distribution.

In this PR, we add a note about it.
(This is an idea from @phil-opp )

## What 

- add limitations section to docs of `Gaussian::fit`