### PR TITLE
chore: migrate renovate preset to tasshi-me/configs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>tasshi-me/renovate-config"]
+  "extends": ["github>tasshi-me/configs"]
 }


### PR DESCRIPTION
The shareable Renovate preset moved from `tasshi-me/renovate-config` to [`tasshi-me/configs`](https://github.com/tasshi-me/configs). This updates the `extends` reference accordingly. `renovate-config` will be archived afterwards.